### PR TITLE
Add a 5-day cooldown to Dependabot & npm-check-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     target-branch: "2.x"
     ignore:
       - dependency-name: "bootstrap"
@@ -15,6 +15,8 @@ updates:
       - dependency-name: "stylelint"
       - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
     labels:
       - "ci"
       - "2.0.x only"
@@ -27,7 +29,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     target-branch: "main"
     ignore:
       - dependency-name: "bootstrap"
@@ -39,6 +41,8 @@ updates:
       - dependency-name: "stylelint"
       - dependency-name: "vnu-jar"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
     labels:
       - "ci"
     groups:
@@ -50,39 +54,47 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     target-branch: "2.x"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
     labels:
       - "ci"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     target-branch: "main"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
     labels:
       - "ci"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     target-branch: "2.x"
+    cooldown:
+      default-days: 5
     labels:
       - "ci"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     target-branch: "main"
+    cooldown:
+      default-days: 5
     labels:
       - "ci"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-minify-bundle": "terser --compress passes=2,typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/arizona-bootstrap.bundle.js.map,includeSources,url=arizona-bootstrap.bundle.min.js.map\" --output dist/js/arizona-bootstrap.bundle.min.js dist/js/arizona-bootstrap.bundle.js",
     "lint": "npm-run-all  --aggregate-output --continue-on-error --parallel js-lint css-lint",
     "test": "npm-run-all lint dist docs-build docs-lint",
-    "update-deps": "ncu -u -x \"bootstrap,eslint,eslint-config-xo,eslint-plugin-unicorn,jquery,sass,stylelint,vnu-jar\"",
+    "update-deps": "ncu --cooldown 5 -u -x \"bootstrap,eslint,eslint-config-xo,eslint-plugin-unicorn,jquery,sass,stylelint,vnu-jar\"",
     "release-sri": "node build/generate-sri.mjs",
     "version": "npm-run-all dist release-sri docs-serve-config docs-build",
     "watch": "npm-run-all --parallel watch-*",


### PR DESCRIPTION
Also, make daily Dependabot checks the norm.